### PR TITLE
Add Gender to CharacterAchievement response

### DIFF
--- a/TauriApiWrapper/Objects/Responses/Achievement/CharacterAchievements.cs
+++ b/TauriApiWrapper/Objects/Responses/Achievement/CharacterAchievements.cs
@@ -37,6 +37,9 @@ namespace TauriApiWrapper.Objects.Responses.Achievement
         [JsonProperty("race")]
         public Race Race { get; set; }
 
+        [JsonProperty("gender")]
+        public Gender Gender { get; set; }
+
         [JsonProperty("name")]
         public string Name { get; set; }
 


### PR DESCRIPTION
The `character-achievements` url returns gender along with the response